### PR TITLE
[Star Wars Saga Edition] Update: Removed nonheroic level from damage

### DIFF
--- a/Star Wars Saga Edition/StarWarsSagaEdition.html
+++ b/Star Wars Saga Edition/StarWarsSagaEdition.html
@@ -430,7 +430,7 @@
 							<span class="table-data" style="width:44px">		</span> 
 							<span class="table-data atkFormula">	
 								<span class="small"><b>Damage Modifier Total Formula</b></span>	<br />						
-								<textarea type="text" name="attr_DamageTotal" class="atkFormula" title="Damage Total formula @{repeating_attack_X_DamageTotal}" >@{level|max}[Half Level] + @{damageMod}[Mod] + @{damageMisc}[Misc]</textarea> 	
+								<textarea type="text" name="attr_DamageTotal" class="atkFormula" title="Damage Total formula @{repeating_attack_X_DamageTotal}" >[[(floor(@{level}/2))]][Half Level] + @{damageMod}[Mod] + @{damageMisc}[Misc]</textarea> 	
 								<span class="small"><b>Damage Roll Formula</b></span>	<br />					
 								<textarea type="text" name="attr_WeaponDamage" class="atkFormula" title="Damage formula @{repeating_attack_X_WeaponDamage}" >@{damage}[Damage] + @{DamageTotal}</textarea> 
 							</span>
@@ -1756,7 +1756,7 @@
 				<button type="roll" name="roll_PCStatBlock-Self" value="/w @{character_name} &{template:statBlock} @{PCStatBlock}" title="Send Character Stat Block to Self" class="blank-roll-button">Self</button>
 			</div> 	
 			<input type="checkbox" class="sect-show hidden" value="1" name="attr_statBlock-show" />			
-				<textarea type="text" name="attr_PCStatBlock" class="StatBlock sect" title="Stat Block Template Roll information"> {{name=@{character_name}}} {{size=@{size}}} {{gender=@{gender}}} {{race=@{species}}} {{class=@{rank}}} {{destiny=@{Destiny}}} {{background=@{background}}} {{force=@{fp}}} {{forcedice=@{fp|max}}} {{dsp=@{dsp}}} {{init=[[@{Initiative}]]}} {{perception=[[@{perception}]]}} {{perception-notes=@{perception|max}}} {{language=@{language}}} {{ref=[[@{Reflex}]]}} {{flatref=[[@{ReflexFlatFooted}]]}} {{fort=[[@{Fortitude}]]}} {{will=[[@{will}]]}} {{hp=@{hp}/@{hp|max}}} {{ct=@{ct}}} {{dt=[[@{dt}]]}} {{immune=@{immune}}} {{speed=@{speed}}} {{meleeatk=[[ @{bab}+@{str|max} ]]}} {{meleedmg=[[ @{str|max}+@{level|max} ]]}} {{rangedatk=[[ @{bab}+@{dex|max} ]]}} {{rangeddmg=@{level|max}}} {{bab=@{bab}}} {{grapple=[[@{Grapple}]]}} {{atkoptions=@{AttackOptions}}} {{specialactions=@{SpecialActions}}} {{utf=[[@{usetheforce}]]}} {{powers=@{ForcePowers}}} {{regimens=@{ForceRegimens}}} {{secrets=@{ForceSecrets}}} {{techniques=@{ForceTechniques}}} {{maneuvers=@{StarshipManeuvers}}} {{systems=@{DroidSystems}}} {{str=@{str} (@{str|max})}} {{dex=@{dex} (@{dex|max})}} {{con=@{con} (@{con|max})}} {{int=@{int} (@{int|max})}} {{wis=@{wis} (@{wis|max})}} {{cha=@{cha} (@{cha|max})}} {{specialqualities=@{SpecialQualities}}} {{talent=@{Talents}}} {{feat=@{feats}}}</textarea>
+				<textarea type="text" name="attr_PCStatBlock" class="StatBlock sect" title="Stat Block Template Roll information"> {{name=@{character_name}}} {{size=@{size}}} {{gender=@{gender}}} {{race=@{species}}} {{class=@{rank}}} {{destiny=@{Destiny}}} {{background=@{background}}} {{force=@{fp}}} {{forcedice=@{fp|max}}} {{dsp=@{dsp}}} {{init=[[@{Initiative}]]}} {{perception=[[@{perception}]]}} {{perception-notes=@{perception|max}}} {{language=@{language}}} {{ref=[[@{Reflex}]]}} {{flatref=[[@{ReflexFlatFooted}]]}} {{fort=[[@{Fortitude}]]}} {{will=[[@{will}]]}} {{hp=@{hp}/@{hp|max}}} {{ct=@{ct}}} {{dt=[[@{dt}]]}} {{immune=@{immune}}} {{speed=@{speed}}} {{meleeatk=[[ @{bab}+@{str|max} ]]}} {{meleedmg=[[ @{str|max}+[[(floor(@{level}/2))]] ]]}} {{rangedatk=[[ @{bab}+@{dex|max} ]]}} {{rangeddmg=[[(floor(@{level}/2))]]}} {{bab=@{bab}}} {{grapple=[[@{Grapple}]]}} {{atkoptions=@{AttackOptions}}} {{specialactions=@{SpecialActions}}} {{utf=[[@{usetheforce}]]}} {{powers=@{ForcePowers}}} {{regimens=@{ForceRegimens}}} {{secrets=@{ForceSecrets}}} {{techniques=@{ForceTechniques}}} {{maneuvers=@{StarshipManeuvers}}} {{systems=@{DroidSystems}}} {{str=@{str} (@{str|max})}} {{dex=@{dex} (@{dex|max})}} {{con=@{con} (@{con|max})}} {{int=@{int} (@{int|max})}} {{wis=@{wis} (@{wis|max})}} {{cha=@{cha} (@{cha|max})}} {{specialqualities=@{SpecialQualities}}} {{talent=@{Talents}}} {{feat=@{feats}}}</textarea>
 		</div>
 		<div class="col">
 			<div class="textHead2Col">Reveal Sections</div>
@@ -1970,7 +1970,7 @@
 					<td class="col1" rowspan="2">Reflex</td>
 					<td></td>
 					<td><input type="number" name="attr_NPC-Reflex" value="@{RefTotal}+@{npc-ct}" disabled="true"  title="Reflex" /></td> 
-					<td><input type="text" name="attr_RefTotal" value="10+@{level}+@{Dex|max}+@{RefSizeMod}"  title="Reflex Total (You can use formulas, for example: 10+@{level|max}[Half Level]+@{Dex|max} or enter the total Defence Score)"/></td>
+					<td><input type="text" name="attr_RefTotal" value="10+@{level}+@{Dex|max}+@{RefSizeMod}"  title="Reflex Total (You can use formulas, for example: 10+@{level}[Level]+@{Dex|max} or enter the total Defence Score)"/></td>
 				</tr>
 					<input type="hidden" name="attr_dexpenalty" title="dexpenalty" value="( [[ (0-floor((@{dex|max} +0.1)/(abs(@{dex|max}+0.1) +0.001))*@{dex|max}) ]] )" disabled="true" />				
 				<tr>
@@ -2033,7 +2033,7 @@
 									&nbsp;+&nbsp;	
 									<input type="number" name="attr_DamageTotal" value="@{damage|max}" disabled="true"  title="Damage Total @{repeating_npc-attack_X_DamageTotal}" />	</span>
 								<span class="table-data center">	&nbsp;|&nbsp;</span>
-								<span class="table-data center">	<input type="text" name="attr_damage_max" value="@{STR|max}+@{level|max}"  style="width:100%" title="Weapon Damage Bonus (You can use formulas, for example: (@{STR|max}*2)+@{level|max} or enter the entire Damage roll for example: 6) @{repeating_npc-attack_X_damage|max}"/>	</span>								
+								<span class="table-data center">	<input type="text" name="attr_damage_max" value="@{STR|max}+[[(floor(@{level}/2))]]"  style="width:100%" title="Weapon Damage Bonus (You can use formulas, for example: (@{STR|max}*2)+[[(floor(@{level}/2))]] or enter the entire Damage roll for example: 6) @{repeating_npc-attack_X_damage|max}"/>	</span>								
 							</div>
 						</div>	</span>
 					</div>


### PR DESCRIPTION
@{level|max} is a calculation which finds half of the heroic plus nonheroic levels. This is fine for things like skills, but it should not be used for damage. Only heroic levels.

<!-- ATTENTION: This Pull Request template changed on 03/17/22. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [ x] The pull request title clearly contains the name of the sheet I am editing.
- [x ] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x ] The pull request makes changes to files in only one sub-folder.
- [ x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description

<!-- This is an optional step, but detailing the nature of the changes makes it easier for other contributors to track down bugs and fix issues -->

@{level|max} contains the calculation for half of the combined heroic and nonheroic levels. This is fine for things like skill checks, but it should not apply to damage calculations.


