### PR TITLE
[Star Wars Saga Edition] Fix: Removed extraneous bracket from roll

### DIFF
--- a/Star Wars Saga Edition/StarWarsSagaEdition.html
+++ b/Star Wars Saga Edition/StarWarsSagaEdition.html
@@ -2466,19 +2466,19 @@
 				<td class="col1">STR<br><div class="small">Strength</div></td>
 				<td><input type="number" name="attr_vehicle-STR" value="8" title="Strength Score" /></td>
 				<td><input type="number" name="attr_vehicle-Str_max" value="[[floor(@{vehicle-STR}/2-5)]]" disabled="true" title="Strength Modifier" /></td>
-				<td><button type="roll" name="roll_vehicle-STRCheck" value="&{template:skill} {{name=Strength}}} {{skill=[[ 1d20+@{vehicle-Str|max}+@{vehicle-CT}]]}}" title="Roll Strength"></button></td>
+				<td><button type="roll" name="roll_vehicle-STRCheck" value="&{template:skill} {{name=Strength}} {{skill=[[ 1d20+@{vehicle-Str|max}+@{vehicle-CT}]]}}" title="Roll Strength"></button></td>
 			</tr>
 			<tr>
 				<td class="col1">DEX<br><div class="small">Dexterity</div></td>
 				<td><input type="number" name="attr_vehicle-DEX" value="8" title="Dexterity Score" /></td>
 				<td><input type="number" name="attr_vehicle-DEX_max" value="[[floor(@{vehicle-DEX}/2-5)]]" disabled="true" title="Dexterity Modifier" /></td>
-				<td><button type="roll" name="roll_vehicle-DEXCheck" value="&{template:skill} {{name=Dexterity}}} {{skill=[[ 1d20+@{vehicle-dex|max}+@{vehicle-CT}]]}}" title="Roll Dexterity"></button></td>
+				<td><button type="roll" name="roll_vehicle-DEXCheck" value="&{template:skill} {{name=Dexterity}} {{skill=[[ 1d20+@{vehicle-dex|max}+@{vehicle-CT}]]}}" title="Roll Dexterity"></button></td>
 			</tr>
 			<tr>
 				<td class="col1">INT<br><div class="small">Intelligence</div></td>
 				<td><input type="number" name="attr_vehicle-INT" value="8" title="Intelligence Score" /></td>
 				<td><input type="number" name="attr_vehicle-INT_max" value="[[floor(@{vehicle-INT}/2-5)]]" disabled="true" title="Intelligence Modifier" /></td>
-				<td><button type="roll" name="roll_vehicle-INTCheck" value="&{template:skill} {{name=Intelligence}}} {{skill=[[ 1d20+@{vehicle-int|max}+@{vehicle-CT}]]}}" title="Roll Intelligence"></button></td>
+				<td><button type="roll" name="roll_vehicle-INTCheck" value="&{template:skill} {{name=Intelligence}} {{skill=[[ 1d20+@{vehicle-int|max}+@{vehicle-CT}]]}}" title="Roll Intelligence"></button></td>
 			</tr>
 		  </tbody>
 		</table>


### PR DESCRIPTION
Vehicle rolls would display as 
Strength}
(or Dex or Int), with an extra bracket in the name.

<!-- ATTENTION: This Pull Request template changed on 03/17/22. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [x ] The pull request title clearly contains the name of the sheet I am editing.
- [x ] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x ] The pull request makes changes to files in only one sub-folder.
- [x ] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description

<!-- This is an optional step, but detailing the nature of the changes makes it easier for other contributors to track down bugs and fix issues -->




